### PR TITLE
InvalidCharacterException.fillInStackTrace synchronized lgtm warning fix

### DIFF
--- a/src/main/java/walkingkooka/tree/json/marshall/InvalidCharacterException.java
+++ b/src/main/java/walkingkooka/tree/json/marshall/InvalidCharacterException.java
@@ -29,7 +29,7 @@ final class InvalidCharacterException extends walkingkooka.InvalidCharacterExcep
     }
 
     @Override
-    public Throwable fillInStackTrace() {
+    public synchronized Throwable fillInStackTrace() {
         return this;
     }
 }


### PR DESCRIPTION
- NEWMethod 'fillInStackTrace' overrides a synchronized method in java.lang.Throwable but is not synchronized.