### PR TITLE
Test constant naming improvements

### DIFF
--- a/src/test/java/walkingkooka/tree/json/JsonArrayTest.java
+++ b/src/test/java/walkingkooka/tree/json/JsonArrayTest.java
@@ -677,16 +677,16 @@ public final class JsonArrayTest extends JsonParentNodeTestCase<JsonArray, List<
 
     @Override
     List<String> propertiesNeverReturnNullSkipProperties() {
-        return Lists.of(BOOLEAN_VALUE_OR_FAIL,
+        return Lists.of(BOOLEAN_OR_FAIL,
                 CHARACTER_OR_FAIL,
                 UNMARSHALL_LIST,
                 UNMARSHALL_SET,
                 UNMARSHALL_MAP,
                 UNMARSHALL,
-                NUMBER_VALUE_OR_FAIL,
+                NUMBER_OR_FAIL,
                 OBJECT_OR_FAIL,
                 PARENT_OR_FAIL,
-                STRING_VALUE_OR_FAIL,
+                STRING_OR_FAIL,
                 VALUE);
     }
 }

--- a/src/test/java/walkingkooka/tree/json/JsonBooleanTest.java
+++ b/src/test/java/walkingkooka/tree/json/JsonBooleanTest.java
@@ -143,9 +143,9 @@ public final class JsonBooleanTest extends JsonLeafNonNullNodeTestCase<JsonBoole
                 UNMARSHALL_SET,
                 UNMARSHALL_MAP,
                 UNMARSHALL,
-                NUMBER_VALUE_OR_FAIL,
+                NUMBER_OR_FAIL,
                 OBJECT_OR_FAIL,
                 PARENT_OR_FAIL,
-                STRING_VALUE_OR_FAIL);
+                STRING_OR_FAIL);
     }
 }

--- a/src/test/java/walkingkooka/tree/json/JsonNodeTestCase.java
+++ b/src/test/java/walkingkooka/tree/json/JsonNodeTestCase.java
@@ -107,16 +107,16 @@ public abstract class JsonNodeTestCase<N extends JsonNode> implements BeanProper
     abstract List<String> propertiesNeverReturnNullSkipProperties();
 
     final static String ARRAY_OR_FAIL = "arrayOrFail";
-    final static String BOOLEAN_VALUE_OR_FAIL = "booleanOrFail";
+    final static String BOOLEAN_OR_FAIL = "booleanOrFail";
     final static String CHARACTER_OR_FAIL = "characterOrFail";
     final static String UNMARSHALL_LIST = "unmarshallWithTypeList";
     final static String UNMARSHALL_SET = "unmarshallWithTypeSet";
     final static String UNMARSHALL_MAP = "unmarshallWithTypeMap";
     final static String UNMARSHALL = "unmarshallWithType";
-    final static String NUMBER_VALUE_OR_FAIL = "numberOrFail";
+    final static String NUMBER_OR_FAIL = "numberOrFail";
     final static String OBJECT_OR_FAIL = "objectOrFail";
     final static String PARENT_OR_FAIL = "parentOrFail";
-    final static String STRING_VALUE_OR_FAIL = "stringOrFail";
+    final static String STRING_OR_FAIL = "stringOrFail";
     final static String VALUE = "value";
 
     // JsonNodeVisitor..................................................................................................

--- a/src/test/java/walkingkooka/tree/json/JsonNullTest.java
+++ b/src/test/java/walkingkooka/tree/json/JsonNullTest.java
@@ -107,16 +107,16 @@ public final class JsonNullTest extends JsonLeafNodeTestCase<JsonNull, Void> {
     @Override
     List<String> propertiesNeverReturnNullSkipProperties() {
         return Lists.of(ARRAY_OR_FAIL,
-                BOOLEAN_VALUE_OR_FAIL,
+                BOOLEAN_OR_FAIL,
                 CHARACTER_OR_FAIL,
                 UNMARSHALL_LIST,
                 UNMARSHALL_SET,
                 UNMARSHALL_MAP,
                 UNMARSHALL,
-                NUMBER_VALUE_OR_FAIL,
+                NUMBER_OR_FAIL,
                 OBJECT_OR_FAIL,
                 PARENT_OR_FAIL,
-                STRING_VALUE_OR_FAIL,
+                STRING_OR_FAIL,
                 VALUE);
     }
 }

--- a/src/test/java/walkingkooka/tree/json/JsonNumberTest.java
+++ b/src/test/java/walkingkooka/tree/json/JsonNumberTest.java
@@ -116,7 +116,7 @@ public final class JsonNumberTest extends JsonLeafNonNullNodeTestCase<JsonNumber
     @Override
     List<String> propertiesNeverReturnNullSkipProperties() {
         return Lists.of(ARRAY_OR_FAIL,
-                BOOLEAN_VALUE_OR_FAIL,
+                BOOLEAN_OR_FAIL,
                 CHARACTER_OR_FAIL,
                 UNMARSHALL_LIST,
                 UNMARSHALL_SET,
@@ -124,6 +124,6 @@ public final class JsonNumberTest extends JsonLeafNonNullNodeTestCase<JsonNumber
                 UNMARSHALL,
                 OBJECT_OR_FAIL,
                 PARENT_OR_FAIL,
-                STRING_VALUE_OR_FAIL);
+                STRING_OR_FAIL);
     }
 }

--- a/src/test/java/walkingkooka/tree/json/JsonObjectTest.java
+++ b/src/test/java/walkingkooka/tree/json/JsonObjectTest.java
@@ -894,15 +894,15 @@ public final class JsonObjectTest extends JsonParentNodeTestCase<JsonObject, Jso
     @Override
     List<String> propertiesNeverReturnNullSkipProperties() {
         return Lists.of(ARRAY_OR_FAIL,
-                BOOLEAN_VALUE_OR_FAIL,
+                BOOLEAN_OR_FAIL,
                 CHARACTER_OR_FAIL,
                 UNMARSHALL_LIST,
                 UNMARSHALL_SET,
                 UNMARSHALL_MAP,
                 UNMARSHALL,
-                NUMBER_VALUE_OR_FAIL,
+                NUMBER_OR_FAIL,
                 PARENT_OR_FAIL,
-                STRING_VALUE_OR_FAIL,
+                STRING_OR_FAIL,
                 VALUE);
     }
 

--- a/src/test/java/walkingkooka/tree/json/JsonStringTest.java
+++ b/src/test/java/walkingkooka/tree/json/JsonStringTest.java
@@ -142,12 +142,12 @@ public final class JsonStringTest extends JsonLeafNonNullNodeTestCase<JsonString
     @Override
     List<String> propertiesNeverReturnNullSkipProperties() {
         return Lists.of(ARRAY_OR_FAIL,
-                BOOLEAN_VALUE_OR_FAIL,
+                BOOLEAN_OR_FAIL,
                 UNMARSHALL_LIST,
                 UNMARSHALL_SET,
                 UNMARSHALL_MAP,
                 UNMARSHALL,
-                NUMBER_VALUE_OR_FAIL,
+                NUMBER_OR_FAIL,
                 OBJECT_OR_FAIL,
                 PARENT_OR_FAIL);
     }


### PR DESCRIPTION
- Matches method naming changes:

- https://github.com/mP1/walkingkooka-tree-json/pull/92
- JsonNode.stringOrFail was stringValueOrFail

- https://github.com/mP1/walkingkooka-tree-json/pull/91
- JsonNode.numberOrFail was numberValueOrFail

- https://github.com/mP1/walkingkooka-tree-json/pull/90
- JsonNode.booleanOrFail was booleanValueOrFail