### PR TITLE
Include unknown type name in exception message

### DIFF
--- a/src/main/java/walkingkooka/tree/json/marshall/BasicJsonNodeUnmarshallContextJsonNodeVisitor.java
+++ b/src/main/java/walkingkooka/tree/json/marshall/BasicJsonNodeUnmarshallContextJsonNodeVisitor.java
@@ -85,7 +85,8 @@ final class BasicJsonNodeUnmarshallContextJsonNodeVisitor extends JsonNodeVisito
 
             final JsonNodeUnmarshallContext context = this.context;
             this.value = context.unmarshall(node.getOrFail(BasicJsonNodeContext.VALUE),
-                    context.registeredType((JsonString) type).orElseThrow(() -> new JsonNodeUnmarshallException("Unknown type", node)));
+                    context.registeredType((JsonString) type)
+                            .orElseThrow(() -> new JsonNodeUnmarshallException("Unknown type: " + type.stringOrFail(), node)));
         } catch (final java.lang.NullPointerException | JsonNodeUnmarshallException cause) {
             throw cause;
         } catch (final RuntimeException cause) {

--- a/src/test/java/walkingkooka/tree/json/marshall/BasicJsonNodeUnmarshallContextJsonNodeVisitorTest.java
+++ b/src/test/java/walkingkooka/tree/json/marshall/BasicJsonNodeUnmarshallContextJsonNodeVisitorTest.java
@@ -20,7 +20,6 @@ package walkingkooka.tree.json.marshall;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import walkingkooka.reflect.JavaVisibility;
-import walkingkooka.tree.expression.ExpressionNumberContext;
 import walkingkooka.tree.expression.ExpressionNumberContexts;
 import walkingkooka.tree.expression.ExpressionNumberKind;
 import walkingkooka.tree.json.JsonNode;
@@ -67,6 +66,16 @@ public final class BasicJsonNodeUnmarshallContextJsonNodeVisitorTest implements 
     public void testNumber() {
         final double number = 12.5;
         this.valueAndCheck(JsonNode.number(number), number);
+    }
+
+    @Test
+    public void testUnknownTypeFails() {
+        final JsonNode typeAndValue = JsonNode.object()
+                .set(BasicJsonNodeContext.TYPE, JsonNode.string("unknown-type-123-???"))
+                .set(BasicJsonNodeContext.VALUE, JsonNode.booleanNode(false));
+
+        final JsonNodeUnmarshallException thrown = assertThrows(JsonNodeUnmarshallException.class, () -> BasicJsonNodeUnmarshallContextJsonNodeVisitor.value(typeAndValue, this.context()));
+        assertEquals("Unknown type: unknown-type-123-???", thrown.getMessage(), "thrown message");
     }
 
     @Test


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-tree-json/issues/100
- Improved unknown type message, currently doesnt include type name