### PR TITLE
JsonNodeContext.register LocalDateTime as "local-date-time" was "loca…

### DIFF
--- a/src/main/java/walkingkooka/tree/json/marshall/BasicJsonMarshallerTypedLocalDateTime.java
+++ b/src/main/java/walkingkooka/tree/json/marshall/BasicJsonMarshallerTypedLocalDateTime.java
@@ -43,7 +43,7 @@ final class BasicJsonMarshallerTypedLocalDateTime extends BasicJsonMarshallerTyp
 
     @Override
     String typeName() {
-        return "local-datetime";
+        return "local-date-time";
     }
 
     @Override

--- a/src/main/java/walkingkooka/tree/json/marshall/JsonNodeContextTesting.java
+++ b/src/main/java/walkingkooka/tree/json/marshall/JsonNodeContextTesting.java
@@ -113,7 +113,7 @@ public interface JsonNodeContextTesting<C extends JsonNodeContext> extends Conte
 
     @Test
     default void testRegisteredTypeLocalDateTime() {
-        this.registeredTypeAndCheck(JsonNode.string("local-datetime"), Optional.ofNullable(LocalDateTime.class));
+        this.registeredTypeAndCheck(JsonNode.string("local-date-time"), Optional.ofNullable(LocalDateTime.class));
     }
 
     @Test
@@ -225,7 +225,7 @@ public interface JsonNodeContextTesting<C extends JsonNodeContext> extends Conte
 
     @Test
     default void testTypeNameLocalDateTime() {
-        this.typeNameAndCheck(LocalDateTime.class, Optional.of(JsonNode.string("local-datetime")));
+        this.typeNameAndCheck(LocalDateTime.class, Optional.of(JsonNode.string("local-date-time")));
     }
 
     @Test

--- a/src/test/java/walkingkooka/tree/json/marshall/BasicJsonMarshallerTypedLocalDateTimeTest.java
+++ b/src/test/java/walkingkooka/tree/json/marshall/BasicJsonMarshallerTypedLocalDateTimeTest.java
@@ -52,7 +52,7 @@ public final class BasicJsonMarshallerTypedLocalDateTimeTest extends BasicJsonMa
 
     @Override
     String typeName() {
-        return "local-datetime";
+        return "local-date-time";
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/json/marshall/BasicJsonNodeContextTestCase.java
+++ b/src/test/java/walkingkooka/tree/json/marshall/BasicJsonNodeContextTestCase.java
@@ -78,7 +78,7 @@ public abstract class BasicJsonNodeContextTestCase<C extends JsonNodeContext> ex
                 "json-property-name",
                 "list",
                 "local-date",
-                "local-datetime",
+                "local-date-time",
                 "local-time",
                 "locale",
                 "long",


### PR DESCRIPTION
…l-datetime"

- Closes JsonNodeContext.register LocalDateTime as "local-date-time"
- https://github.com/mP1/walkingkooka-tree-json/issues/105