### PR TITLE
JsonString parser toJson single quote fix

### DIFF
--- a/src/main/java/walkingkooka/tree/json/JsonString.java
+++ b/src/main/java/walkingkooka/tree/json/JsonString.java
@@ -97,8 +97,64 @@ public final class JsonString extends JsonLeafNonNullNode<String> {
         return other instanceof JsonString;
     }
 
+    // https://www.json.org/json-en.html
+    // https://en.wikipedia.org/wiki/JSON
+
+    /**
+     * https://www.crockford.com/mckeeman.html
+     * <pre>
+     * character
+     * '0020' . '10FFFF' - '"' - '\'
+     * '\' escape
+     * </pre>
+     *
+     * @param printer
+     */
     @Override
     void printJson0(final IndentingPrinter printer) {
-        printer.print(CharSequences.quoteAndEscape(this.value));
+        final String value = this.value;
+        final int length = value.length();
+
+        final StringBuilder encoded = new StringBuilder();
+        encoded.append('"'); // open
+
+        for (int i = 0; i < length; i++) {
+            final char c = value.charAt(i);
+
+            switch (c) {
+                case '"':
+                    encoded.append("\\\"");
+                    break;
+                case '\\':
+                    encoded.append("\\\\");
+                    break;
+                case '\b':
+                    encoded.append("\\b");
+                    break;
+                case '\f':
+                    encoded.append("\\f");
+                    break;
+                case '\n':
+                    encoded.append("\\n");
+                    break;
+                case '\r':
+                    encoded.append("\\r");
+                    break;
+                case '\t':
+                    encoded.append("\\t");
+                    break;
+                default:
+                    if (c < 0x20 || c >= 0x10FFFF) {
+                        encoded.append("\\u").append(CharSequences.padLeft(Integer.toHexString(c), 4, '0'));
+                        break;
+                    }
+                    encoded.append(c);
+                    break;
+            }
+        }
+
+        encoded.append('"'); // close
+
+        printer.print(encoded);
     }
 }

--- a/src/main/java/walkingkooka/tree/json/parser/JsonNodeParsers.java
+++ b/src/main/java/walkingkooka/tree/json/parser/JsonNodeParsers.java
@@ -135,15 +135,7 @@ public final class JsonNodeParsers implements PublicStaticHelper {
      * String
      */
     public static Parser<ParserContext> string() {
-        return STRING;
-    }
-
-    private final static Parser<ParserContext> STRING = Parsers.doubleQuoted()
-            .transform(JsonNodeParsers::transformString)
-            .setToString(JsonNodeStringParserToken.class.getSimpleName());
-
-    private static ParserToken transformString(final ParserToken token, final ParserContext context) {
-        return JsonNodeParserToken.string(token.cast(DoubleQuotedParserToken.class).value(), token.text());
+        return JsonNodeParsersStringParser.INSTANCE;
     }
 
     /**

--- a/src/main/java/walkingkooka/tree/json/parser/JsonNodeParsersStringParser.java
+++ b/src/main/java/walkingkooka/tree/json/parser/JsonNodeParsersStringParser.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.json.parser;
+
+import walkingkooka.text.cursor.TextCursor;
+import walkingkooka.text.cursor.TextCursorLineInfo;
+import walkingkooka.text.cursor.TextCursorSavePoint;
+import walkingkooka.text.cursor.parser.Parser;
+import walkingkooka.text.cursor.parser.ParserContext;
+import walkingkooka.text.cursor.parser.ParserToken;
+
+import java.util.Optional;
+
+/**
+ * A parser that consumes JSON strings.
+ * https://www.crockford.com/mckeeman.html
+ */
+final class JsonNodeParsersStringParser implements Parser<ParserContext> {
+
+    /**
+     * Singleton
+     */
+    final static JsonNodeParsersStringParser INSTANCE = new JsonNodeParsersStringParser();
+
+    /**
+     * Stop sub classing
+     */
+    private JsonNodeParsersStringParser() {
+        super();
+    }
+
+    @Override
+    public Optional<ParserToken> parse(final TextCursor cursor, final ParserContext context) {
+        JsonNodeParserToken token = null;
+
+        if (!cursor.isEmpty()) {
+            final char first = cursor.at();
+            if (DOUBLE_QUOTE == first) {
+                final TextCursorSavePoint save = cursor.save();
+                final StringBuilder decoded = new StringBuilder();
+                int mode = 0;
+                int unicode = 0;
+                int unicodeLength = 0;
+
+                cursor.next();
+
+                Exit:
+                for (; ; ) {
+                    if (cursor.isEmpty()) {
+                        throw new JsonNodeParserException("Unterminated string");
+                    }
+
+                    final char c = cursor.at();
+
+                    switch (mode) {
+                        case MODE_LITERAL:
+                            switch (c) {
+                                case BACKSLASH:
+                                    mode = MODE_BACKSLASH;
+                                    break;
+                                case DOUBLE_QUOTE:
+                                    cursor.next();
+                                    token = JsonNodeParserToken.string(
+                                            decoded.toString(),
+                                            save.textBetween().toString()
+                                    );
+                                    break Exit;
+                                default:
+                                    decoded.append(c);
+                                    break;
+                            }
+                            break;
+                        case MODE_BACKSLASH:
+                            mode = MODE_LITERAL; // all unescaping will change mode=MODE_LITERAL except unicode=MODE_UNICODE
+
+                            switch (c) {
+                                case 'b':
+                                    decoded.append('\b');
+                                    break;
+                                case 'f':
+                                    decoded.append('\f');
+                                    break;
+                                case 'n':
+                                    decoded.append('\n');
+                                    break;
+                                case 'r':
+                                    decoded.append('\r');
+                                    break;
+                                case 't':
+                                    decoded.append('\t');
+                                    break;
+                                case 'u':
+                                    unicode = 0;
+                                    mode = MODE_UNICODE;
+                                    break;
+                                default:
+                                    // also handles decoding DOUBLE_QUOTE
+                                    decoded.append(c);
+                                    break;
+                            }
+                            break;
+                        case MODE_UNICODE:
+                            final int hexValue = Character.digit(c, 16);
+                            if (-1 == hexValue) {
+                                final TextCursorLineInfo info = cursor.lineInfo();
+                                throw new JsonNodeParserException("Invalid unicode escape sequence" + info.summary());
+                            }
+                            unicode = unicode * 16 + hexValue;
+                            unicodeLength++;
+                            if (unicodeLength == 4) {
+                                mode = MODE_LITERAL;
+                                decoded.append((char)unicode);
+                            }
+                            break;
+                    } // switch
+
+                    cursor.next();
+                }
+            }
+        }
+
+        return Optional.ofNullable(token);
+    }
+
+    final static char DOUBLE_QUOTE = '"';
+    final static char BACKSLASH = '\\';
+
+    private final static int MODE_LITERAL = 0;
+    private final static int MODE_BACKSLASH = MODE_LITERAL + 1;
+    private final static int MODE_UNICODE = MODE_BACKSLASH + 1;
+
+    @Override
+    public String toString() {
+        return "STRING";
+    }
+}

--- a/src/test/java/walkingkooka/tree/json/JsonStringTest.java
+++ b/src/test/java/walkingkooka/tree/json/JsonStringTest.java
@@ -19,6 +19,7 @@ package walkingkooka.tree.json;
 
 import org.junit.jupiter.api.Test;
 import walkingkooka.collect.list.Lists;
+import walkingkooka.text.CharSequences;
 import walkingkooka.tree.search.SearchNode;
 import walkingkooka.visit.Visiting;
 
@@ -104,14 +105,113 @@ public final class JsonStringTest extends JsonLeafNonNullNodeTestCase<JsonString
 
     @Test
     public void testToString() {
-        this.toStringAndCheck(this.createJsonNode("abc123"),
-                "\"abc123\"");
+        this.toStringAndCheck2(
+                "abc123",
+                "\"abc123\""
+        );
     }
 
     @Test
-    public void testToStringRequiresEscaping() {
-        this.toStringAndCheck(this.createJsonNode("abc\t123"),
-                "\"abc\\t123\"");
+    public void testToStringSpace() {
+        this.toStringAndCheck2(
+                "abc 123 ",
+                "\"abc 123 \""
+        );
+    }
+
+    @Test
+    public void testToStringNul() {
+        this.toStringAndCheck2(
+                "abc" + ((char) 0) + "xyz",
+                "\"abc\\u0000xyz\""
+        );
+    }
+
+    @Test
+    public void testToStringBell() {
+        this.toStringAndCheck2(
+                "abc\bxyz",
+                "\"abc\\bxyz\""
+        );
+    }
+
+    @Test
+    public void testToStringCR() {
+        this.toStringAndCheck2(
+                "abc\rxyz",
+                "\"abc\\rxyz\""
+        );
+    }
+
+    @Test
+    public void testToStringFormFeed() {
+        this.toStringAndCheck2(
+                "abc\fxyz",
+                "\"abc\\fxyz\""
+        );
+    }
+
+    @Test
+    public void testToStringNL() {
+        this.toStringAndCheck2(
+                "abc\nxyz",
+                "\"abc\\nxyz\""
+        );
+    }
+
+    @Test
+    public void testToStringStringQuote() {
+        this.toStringAndCheck2(
+                "abc'xyz",
+                "\"abc'xyz\""
+        );
+    }
+
+    @Test
+    public void testToStringDoubleQuote() {
+        this.toStringAndCheck2(
+                "abc\"xyz",
+                "\"abc\\\"xyz\""
+        );
+    }
+
+    @Test
+    public void testToStringTab() {
+        this.toStringAndCheck2(
+                "abc\txyz",
+                "\"abc\\txyz\""
+        );
+    }
+
+    @Test
+    public void testToStringControlCharacter() {
+        this.toStringAndCheck2(
+                "abc" + ((char) 20) + "xyz",
+                "\"abc\\u0014xyz\""
+        );
+    }
+
+    private void toStringAndCheck2(final String value, final String json) {
+        this.toStringAndCheck(
+                this.createJsonNode(value),
+                json
+        );
+    }
+
+    @Test
+    public void testParseToStringRountrip() {
+        for (int i = Character.MIN_VALUE; i < Character.MAX_VALUE; i++) {
+            final char c = (char) i;
+            final String text = Character.toString(c);
+            final JsonString jsonString = JsonNode.string(text);
+            final String json = jsonString.toString();
+
+            assertEquals(
+                    text,
+                    JsonNode.parse(json).stringOrFail(),
+                    () -> "parsing string " + CharSequences.quoteIfChars(c)
+            );
+        }
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/json/parser/JsonNodeParsersStringParserTest.java
+++ b/src/test/java/walkingkooka/tree/json/parser/JsonNodeParsersStringParserTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.tree.json.parser;
+
+import org.junit.jupiter.api.Test;
+import walkingkooka.ToStringTesting;
+import walkingkooka.reflect.TypeNameTesting;
+import walkingkooka.text.cursor.TextCursors;
+import walkingkooka.text.cursor.parser.Parser;
+import walkingkooka.text.cursor.parser.ParserContext;
+import walkingkooka.text.cursor.parser.ParserContexts;
+import walkingkooka.text.cursor.parser.ParserTesting2;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public final class JsonNodeParsersStringParserTest implements ParserTesting2<JsonNodeParsersStringParser, ParserContext>, ToStringTesting<JsonNodeParsersStringParser>,
+        TypeNameTesting<JsonNodeParsersStringParser> {
+
+    @Test
+    public void testUnterminatedFails() {
+        this.parseUnterminatedStringFails("\"");
+    }
+
+    @Test
+    public void testUnterminatedCharacterFails() {
+        this.parseUnterminatedStringFails("\"a");
+    }
+
+    @Test
+    public void testUnterminatedBackslashFails() {
+        this.parseUnterminatedStringFails("\"\\");
+    }
+
+    @Test
+    public void testUnterminatedEscapedDoubleQuoteFails() {
+        this.parseUnterminatedStringFails("\"\\\"");
+    }
+
+    @Test
+    public void testUnterminatedUncodeFails() {
+        this.parseUnterminatedStringFails("\"\\u");
+    }
+
+    @Test
+    public void testUnterminatedUncode1Fails() {
+        this.parseUnterminatedStringFails("\"\\u1");
+    }
+
+    @Test
+    public void testUnterminatedUncode2Fails() {
+        this.parseUnterminatedStringFails("\"\\u12");
+    }
+
+    @Test
+    public void testUnterminatedUncode3Fails() {
+        this.parseUnterminatedStringFails("\"\\u123");
+    }
+
+    @Test
+    public void testUnterminatedUncode4Fails() {
+        this.parseUnterminatedStringFails("\"\\u1234");
+    }
+
+    private void parseUnterminatedStringFails(final String text) {
+        assertThrows(JsonNodeParserException.class, () ->
+                this.createParser().parse(TextCursors.charSequence(text), this.createContext())
+        );
+    }
+
+    @Test
+    public void testLetters() {
+        this.parseAndCheck2("abc");
+    }
+
+    @Test
+    public void testDigits() {
+        this.parseAndCheck2("1234");
+    }
+
+    @Test
+    public void testFF() {
+        this.parseAndCheck2("\\f", "\f");
+    }
+
+    @Test
+    public void testCarriageReturn() {
+        this.parseAndCheck2("\\r", "\r");
+    }
+
+    @Test
+    public void testNewline() {
+        this.parseAndCheck2("\\n", "\n");
+    }
+
+    @Test
+    public void testUnicode0000() {
+        this.parseAndCheck2("\\u0000", "\u0000");
+    }
+
+    @Test
+    public void testUnicode1234() {
+        this.parseAndCheck2("\\u1234", "\u1234");
+    }
+
+    @Test
+    public void testUnicodeABCD() {
+        this.parseAndCheck2("\\uABCD", "\uABCD");
+    }
+
+    @Test
+    public void testUnicodeabcd() {
+        this.parseAndCheck2("\\uabcd", "\uabcd");
+    }
+
+    @Test
+    public void testUnicodeDef0() {
+        this.parseAndCheck2("\\uDef0", "\uDef0");
+    }
+
+    private void parseAndCheck2(final String content) {
+        this.parseAndCheck2(content, content);
+    }
+
+    private void parseAndCheck2(final String content,
+                                final String decoded) {
+
+        this.parseAndCheck3(content, decoded);
+
+        final String before = "before ";
+        final String after = " after";
+        this.parseAndCheck3(
+                before + content + after,
+                before + decoded + after
+        );
+    }
+
+    private void parseAndCheck3(final String content,
+                                final String decoded) {
+
+        final String json = JsonNodeParsersStringParser.DOUBLE_QUOTE + content + JsonNodeParsersStringParser.DOUBLE_QUOTE;
+
+        this.parseAndCheck(
+                json,
+                JsonNodeParserToken.string(decoded, json),
+                json
+        );
+
+        final String after = "" + 1;
+        this.parseAndCheck(
+                json + after,
+                JsonNodeParserToken.string(decoded, json),
+                json,
+                after
+        );
+
+        final String after2 = "" + JsonNodeParsersStringParser.DOUBLE_QUOTE + "hello" + JsonNodeParsersStringParser.DOUBLE_QUOTE;
+        this.parseAndCheck(
+                json + after2,
+                JsonNodeParserToken.string(decoded, json),
+                json,
+                after2
+        );
+    }
+
+    @Test
+    public void testToString() {
+        this.toStringAndCheck(this.createParser(), "STRING");
+    }
+
+    @Override
+    public JsonNodeParsersStringParser createParser() {
+        return JsonNodeParsersStringParser.INSTANCE;
+    }
+
+    @Override
+    public ParserContext createContext() {
+        return ParserContexts.fake();
+    }
+
+    @Override
+    public Class<JsonNodeParsersStringParser> type() {
+        return JsonNodeParsersStringParser.class;
+    }
+
+    // TypeNaming.......................................................................................................
+
+    @Override
+    public String typeNamePrefix() {
+        return JsonNodeParsers.class.getSimpleName();
+    }
+
+    @Override
+    public String typeNameSuffix() {
+        return "String" + Parser.class.getSimpleName();
+    }
+}


### PR DESCRIPTION
- Custom parser created no longer uses Parsers.doubleQuote
- Rewrite of JsonString.toString() using notes from json.org

- Closes https://github.com/mP1/walkingkooka-tree-json/issues/111
- JsonString incorrectly encoding single quote as backslash single apostrophe