### PR TITLE
JsonNode.parse require text completely consumed fix

### DIFF
--- a/src/main/java/walkingkooka/tree/json/JsonNode.java
+++ b/src/main/java/walkingkooka/tree/json/JsonNode.java
@@ -71,6 +71,7 @@ public abstract class JsonNode implements Node<JsonNode, JsonPropertyName, Name,
      * Parser that will consume json or report a parsing error.
      */
     private final static Parser<JsonNodeParserContext> PARSER = JsonNodeParsers.value()
+            .andEmptyTextCursor()
             .orReport(ParserReporters.basic())
             .cast();
 

--- a/src/main/java/walkingkooka/tree/json/marshall/InvalidTextLengthException.java
+++ b/src/main/java/walkingkooka/tree/json/marshall/InvalidTextLengthException.java
@@ -25,9 +25,9 @@ final class InvalidTextLengthException extends walkingkooka.InvalidTextLengthExc
     private static final long serialVersionUID = 1;
 
     InvalidTextLengthException(final String label,
-                                      final String text,
-                                      final int min,
-                                      final int max) {
+                               final String text,
+                               final int min,
+                               final int max) {
         super(label, text, min, max);
     }
 

--- a/src/test/java/walkingkooka/tree/json/JsonNodeTest.java
+++ b/src/test/java/walkingkooka/tree/json/JsonNodeTest.java
@@ -29,8 +29,33 @@ public final class JsonNodeTest implements ClassTesting2<JsonNode>,
         ParseStringTesting<JsonNode> {
 
     @Test
+    public void testKeyMissingValueFails() {
+        this.parseStringFails("\"a1\":", ParserException.class);
+    }
+
+    @Test
+    public void testKeyValuePairFails() {
+        this.parseStringFails("\"a1\": \"b2\"", ParserException.class);
+    }
+
+    @Test
+    public void testKeyValuePairTwiceFails() {
+        this.parseStringFails("\"a1\": \"b2\", \"c3\": \"d4\"", ParserException.class);
+    }
+
+    @Test
     public void testParseIncompleteObjectFails() {
         this.parseStringFails("{\"", ParserException.class);
+    }
+
+    @Test
+    public void testParseIncompleteArrayFails() {
+        this.parseStringFails("[1,", ParserException.class);
+    }
+
+    @Test
+    public void testParseIncompleteArrayFails2() {
+        this.parseStringFails("[1,", ParserException.class);
     }
 
     @Test
@@ -68,6 +93,12 @@ public final class JsonNodeTest implements ClassTesting2<JsonNode>,
     @Test
     public void testParseObject() {
         this.parseStringAndCheck("{\"prop1\": \"value1\"}",
+                JsonNode.object().set(JsonPropertyName.with("prop1"), JsonNode.string("value1")));
+    }
+
+    @Test
+    public void testParseObject2() {
+        this.parseStringAndCheck("{ \"prop1\": \"value1\" }",
                 JsonNode.object().set(JsonPropertyName.with("prop1"), JsonNode.string("value1")));
     }
 

--- a/src/test/java/walkingkooka/tree/json/marshall/BasicJsonMarshallerTypedInvalidCharacterExceptionTest.java
+++ b/src/test/java/walkingkooka/tree/json/marshall/BasicJsonMarshallerTypedInvalidCharacterExceptionTest.java
@@ -66,7 +66,7 @@ public final class BasicJsonMarshallerTypedInvalidCharacterExceptionTest extends
 
     @Override
     JsonNode node() {
-        return JsonNode.parse("{ \"text\": \"some-text-123\", \"position\": 2}}");
+        return JsonNode.parse("{ \"text\": \"some-text-123\", \"position\": 2}");
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/json/marshall/BasicJsonMarshallerTypedInvalidTextLengthExceptionTest.java
+++ b/src/test/java/walkingkooka/tree/json/marshall/BasicJsonMarshallerTypedInvalidTextLengthExceptionTest.java
@@ -68,7 +68,7 @@ public final class BasicJsonMarshallerTypedInvalidTextLengthExceptionTest extend
 
     @Override
     JsonNode node() {
-        return JsonNode.parse("{ \"label\": \"name-of-something-1\", \"text\": \"some-text-123\", \"min\": 2, \"max\": 3}}");
+        return JsonNode.parse("{ \"label\": \"name-of-something-1\", \"text\": \"some-text-123\", \"min\": 2, \"max\": 3}");
     }
 
     @Override


### PR DESCRIPTION
- Additional JsonNode.parse tests
- Fixed BasicJsonMarshallerTypedInvalidCharacterExceptionTest tests
- Fixed BasicJsonMarshallerTypedInvalidTextLengthExceptionTest tests