### PR TITLE
JsonNode improved failed conversions messages

### DIFF
--- a/src/main/java/walkingkooka/tree/json/JsonNode.java
+++ b/src/main/java/walkingkooka/tree/json/JsonNode.java
@@ -250,7 +250,11 @@ public abstract class JsonNode implements Node<JsonNode, JsonPropertyName, Name,
      * If a {@link JsonBoolean} returns the boolean value or fails.
      */
     public final boolean booleanOrFail() {
-        return this.valueOrFail(Boolean.class);
+        if (!this.isBoolean()) {
+            this.reportInvalidNode(Boolean.class);
+        }
+
+        return Cast.to(this.value());
     }
 
     /**
@@ -270,26 +274,22 @@ public abstract class JsonNode implements Node<JsonNode, JsonPropertyName, Name,
      * If a {@link JsonNumber} returns the number value or fails.
      */
     public final Number numberOrFail() {
-        return this.valueOrFail(Number.class);
+        if (!this.isNumber()) {
+            this.reportInvalidNode(Number.class);
+        }
+
+        return Cast.to(this.value());
     }
 
     /**
      * If a {@link JsonString} returns the string value or fails.
      */
     public final String stringOrFail() {
-        return this.valueOrFail(String.class);
-    }
-
-    private <V> V valueOrFail(final Class<V> type) {
-        if (this.isNull()) {
-            this.reportInvalidNode(type);
+        if (!this.isString()) {
+            this.reportInvalidNode(String.class);
         }
 
-        try {
-            return Cast.to(this.value());
-        } catch (final ClassCastException | UnsupportedOperationException fail) {
-            return this.reportInvalidNode(type);
-        }
+        return Cast.to(this.value());
     }
 
     /**
@@ -310,10 +310,11 @@ public abstract class JsonNode implements Node<JsonNode, JsonPropertyName, Name,
     }
 
     /**
-     * Reports a failed attempt to extract a value or cast a node.
+     * Reports a failed attempt to extract a value or cast a node. The message will include the expected and the
+     * target type and its toString representation.
      */
     final <V> V reportInvalidNode(final String type) {
-        throw new ClassCastException("Node is not a " + type + "=" + this);
+        throw new ClassCastException("Expected " + type + " got " + this.defaultName() + ": " + this);
     }
 
     // isXXX............................................................................................................

--- a/src/test/java/walkingkooka/tree/json/JsonNodeTestCase.java
+++ b/src/test/java/walkingkooka/tree/json/JsonNodeTestCase.java
@@ -75,17 +75,23 @@ public abstract class JsonNodeTestCase<N extends JsonNode> implements BeanProper
     // ToXXXValueOrFail.................................................................................................
     @Test
     public void testBooleanOrFail() {
-        assertThrows(ClassCastException.class, () -> this.createNode().booleanOrFail());
+        final JsonNode node = this.createNode();
+        final ClassCastException thrown = assertThrows(ClassCastException.class, node::booleanOrFail);
+        assertEquals("Expected Boolean got " + node.defaultName() + ": " + node, thrown.getMessage());
     }
 
     @Test
     public void testNumberOrFail() {
-        assertThrows(ClassCastException.class, () -> this.createNode().numberOrFail());
+        final JsonNode node = this.createNode();
+        final ClassCastException thrown = assertThrows(ClassCastException.class, node::numberOrFail);
+        assertEquals("Expected Number got " + node.defaultName() + ": " + node, thrown.getMessage());
     }
 
     @Test
     public void testStringOrFail() {
-        assertThrows(ClassCastException.class, () -> this.createNode().stringOrFail());
+        final JsonNode node = this.createNode();
+        final ClassCastException thrown = assertThrows(ClassCastException.class, node::stringOrFail);
+        assertEquals("Expected String got " + node.defaultName() + ": " + node, thrown.getMessage());
     }
 
     @Test
@@ -94,7 +100,8 @@ public abstract class JsonNodeTestCase<N extends JsonNode> implements BeanProper
         if (node instanceof JsonObject) {
             assertSame(node, node.objectOrFail());
         } else {
-            assertThrows(ClassCastException.class, node::objectOrFail);
+            final ClassCastException thrown = assertThrows(ClassCastException.class, node::objectOrFail);
+            assertEquals("Expected Object got " + node.defaultName() + ": " + node, thrown.getMessage());
         }
     }
 


### PR DESCRIPTION
- Fixed casting of java value for boolean/number/string getters.
- Probably due to missing tests on actual thrown message, tests added.