### PR TITLE
JsonArray pretty print missing linebreaks

### DIFF
--- a/src/main/java/walkingkooka/tree/json/JsonArray.java
+++ b/src/main/java/walkingkooka/tree/json/JsonArray.java
@@ -280,16 +280,30 @@ public final class JsonArray extends JsonParentNode<List<JsonNode>> {
 
     @Override
     void printJson0(final IndentingPrinter printer) {
-        printer.print(BEGIN.string());
+        final List<JsonNode> children = this.children();
+        if (children.isEmpty()) {
+            printer.print(EMPTY_ARRAY_STRING);
+        } else {
+            printer.println(BEGIN);
 
-        String separator = "";
-        for (JsonNode child : this.children) {
-            printer.print(separator);
-            separator = ", ";
+            printer.indent();
+            {
+                int i = 0;
+                for (final JsonNode child : this.children) {
+                    if (i > 0) {
+                        printer.println(",");
+                    }
+                    i++;
 
-            child.printJson(printer);
+                    child.printJson(printer);
+                }
+            }
+            printer.outdent();
+
+            printer.println();
+            printer.print(END);
         }
-
-        printer.print(END.string());
     }
+
+    private final static String EMPTY_ARRAY_STRING = BEGIN.string() + END;
 }

--- a/src/test/java/walkingkooka/tree/json/JsonArrayTest.java
+++ b/src/test/java/walkingkooka/tree/json/JsonArrayTest.java
@@ -633,13 +633,33 @@ public final class JsonArrayTest extends JsonParentNodeTestCase<JsonArray, List<
     }
 
     @Test
-    public void testToStringWithChildren() {
+    public void testToStringWithOneChild() {
+        final JsonArray array = JsonNode.array()
+                .appendChild(JsonNode.booleanNode(true));
+
+        this.toStringAndCheck(
+                array,
+                "[\n" +
+                        "  true\n" +
+                        "]"
+        );
+    }
+
+    @Test
+    public void testToStringWithSeveralChildren() {
         final JsonArray array = JsonNode.array()
                 .appendChild(JsonNode.booleanNode(true))
                 .appendChild(JsonNode.number(2))
                 .appendChild(JsonNode.string("third"));
 
-        this.toStringAndCheck(array, "[true, 2, \"third\"]");
+        this.toStringAndCheck(
+                array,
+                "[\n" +
+                        "  true,\n" +
+                        "  2,\n" +
+                        "  \"third\"\n" +
+                        "]"
+        );
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/json/JsonObjectTest.java
+++ b/src/test/java/walkingkooka/tree/json/JsonObjectTest.java
@@ -824,7 +824,10 @@ public final class JsonObjectTest extends JsonParentNodeTestCase<JsonObject, Jso
 
     @Test
     public void testToStringEmpty() {
-        this.toStringAndCheck(this.createJsonNode(), "{}");
+        this.toStringAndCheck(
+                this.createJsonNode(),
+                "{}"
+        );
     }
 
     @Test
@@ -865,7 +868,13 @@ public final class JsonObjectTest extends JsonParentNodeTestCase<JsonObject, Jso
 
         this.toStringAndCheck(
                 object,
-                "{\n  \"key3\": [true, 2, \"third\"]\n}"
+                "{\n" +
+                        "  \"key3\": [\n" +
+                        "    true,\n" +
+                        "    2,\n" +
+                        "    \"third\"\n" +
+                        "  ]\n" +
+                        "}"
         );
     }
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-tree-json/issues/170
- Json pretty print: Missing NL After array start

- Closes https://github.com/mP1/walkingkooka-tree-json/issues/171
- Json pretty print: Missing NL after Json Object | before array END.