### PR TITLE
BasicJsonNodeMarshallContext: UnsupportedTypeJsonNodeException not wr…

### DIFF
--- a/src/main/java/walkingkooka/tree/json/marshall/BasicJsonMarshaller.java
+++ b/src/main/java/walkingkooka/tree/json/marshall/BasicJsonMarshaller.java
@@ -40,6 +40,7 @@ import walkingkooka.tree.expression.PowerExpression;
 import walkingkooka.tree.expression.SubtractExpression;
 import walkingkooka.tree.expression.XorExpression;
 import walkingkooka.tree.json.JsonNode;
+import walkingkooka.tree.json.JsonNodeException;
 import walkingkooka.tree.json.JsonString;
 import walkingkooka.tree.json.UnsupportedTypeJsonNodeException;
 
@@ -251,7 +252,7 @@ abstract class BasicJsonMarshaller<T> {
             return node.isNull() ?
                     this.unmarshallNull(context) :
                     this.unmarshallNonNull(node, context);
-        } catch (final JsonNodeUnmarshallException | java.lang.NullPointerException cause) {
+        } catch (final JsonNodeException | java.lang.NullPointerException cause) {
             throw cause;
         } catch (final RuntimeException cause) {
             throw new JsonNodeUnmarshallException("Failed to unmarshall", node, cause);

--- a/src/test/java/walkingkooka/tree/json/marshall/BasicJsonMarshallerTestCase2.java
+++ b/src/test/java/walkingkooka/tree/json/marshall/BasicJsonMarshallerTestCase2.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import walkingkooka.ToStringTesting;
 import walkingkooka.tree.expression.ExpressionNumberKind;
 import walkingkooka.tree.json.JsonNode;
+import walkingkooka.tree.json.JsonNodeException;
 import walkingkooka.tree.json.JsonObject;
 
 import java.math.MathContext;
@@ -243,24 +244,23 @@ public abstract class BasicJsonMarshallerTestCase2<M extends BasicJsonMarshaller
                 node;
     }
 
-    final void unmarshallFailed(final JsonNode node, final Class<? extends Throwable> wrapped) {
+    final <T extends Throwable> void unmarshallFailed(final JsonNode node,
+                                                      final Class<T> thrown) {
         final JsonNodeUnmarshallContext context = this.unmarshallContext();
 
-        if (java.lang.NullPointerException.class == wrapped) {
-            assertThrows(java.lang.NullPointerException.class, () -> this.marshaller().unmarshall(node, context));
-        } else {
-            final JsonNodeUnmarshallException from = assertThrows(JsonNodeUnmarshallException.class, () -> this.marshaller().unmarshall(node, context));
-            final Throwable cause = from.getCause();
-            if (null == wrapped) {
-                from.printStackTrace();
-                checkEquals(null, cause, "Cause");
-            } else {
-                if (wrapped != cause.getClass()) {
-                    from.printStackTrace();
-                    checkEquals(wrapped, cause, "Wrong cause type");
-                }
-            }
+        Class<? extends Throwable> reallyThrown = JsonNodeUnmarshallException.class;
+        if(JsonNodeException.class.isAssignableFrom(thrown) || java.lang.NullPointerException.class == thrown) {
+            reallyThrown = thrown;
         }
+
+        assertThrows(
+                reallyThrown,
+                () -> this.marshaller()
+                        .unmarshall(
+                                node,
+                                context
+                        )
+        );
     }
 
     final void unmarshallAndCheck(final JsonNode node, final T value) {

--- a/src/test/java/walkingkooka/tree/json/marshall/BasicJsonMarshallerTypedCharacterTest.java
+++ b/src/test/java/walkingkooka/tree/json/marshall/BasicJsonMarshallerTypedCharacterTest.java
@@ -25,7 +25,10 @@ public final class BasicJsonMarshallerTypedCharacterTest extends BasicJsonMarsha
     @Test
     @Override
     public void testUnmarshallJsonNullNode() {
-        this.unmarshallFailed(JsonNode.nullNode(), java.lang.NullPointerException.class);
+        this.unmarshallFailed(
+                JsonNode.nullNode(),
+                java.lang.NullPointerException.class
+        );
     }
 
     @Test

--- a/src/test/java/walkingkooka/tree/json/marshall/BasicJsonMarshallerTypedCollectionListTest.java
+++ b/src/test/java/walkingkooka/tree/json/marshall/BasicJsonMarshallerTypedCollectionListTest.java
@@ -40,17 +40,26 @@ public final class BasicJsonMarshallerTypedCollectionListTest extends BasicJsonM
 
     @Test
     public void testUnmarshallBooleanFails() {
-        this.unmarshallFailed(JsonNode.booleanNode(true), null);
+        this.unmarshallFailed(
+                JsonNode.booleanNode(true),
+                JsonNodeUnmarshallException.class
+        );
     }
 
     @Test
     public void testUnmarshallNumberFails() {
-        this.unmarshallFailed(JsonNode.number(123), null);
+        this.unmarshallFailed(
+                JsonNode.number(123),
+                JsonNodeUnmarshallException.class
+        );
     }
 
     @Test
     public void testUnmarshallStringFails() {
-        this.unmarshallFailed(JsonNode.string("abc123"), null);
+        this.unmarshallFailed(
+                JsonNode.string("abc123"),
+                JsonNodeUnmarshallException.class
+        );
     }
 
     @Test

--- a/src/test/java/walkingkooka/tree/json/marshall/BasicJsonMarshallerTypedCollectionSetTest.java
+++ b/src/test/java/walkingkooka/tree/json/marshall/BasicJsonMarshallerTypedCollectionSetTest.java
@@ -40,22 +40,34 @@ public final class BasicJsonMarshallerTypedCollectionSetTest extends BasicJsonMa
 
     @Test
     public void testUnmarshallBooleanFails() {
-        this.unmarshallFailed(JsonNode.booleanNode(true), null);
+        this.unmarshallFailed(
+                JsonNode.booleanNode(true),
+                JsonNodeUnmarshallException.class
+        );
     }
 
     @Test
     public void testUnmarshallNumberFails() {
-        this.unmarshallFailed(JsonNode.number(123), null);
+        this.unmarshallFailed(
+                JsonNode.number(123),
+                JsonNodeUnmarshallException.class
+        );
     }
 
     @Test
     public void testUnmarshallStringFails() {
-        this.unmarshallFailed(JsonNode.string("abc123"), null);
+        this.unmarshallFailed(
+                JsonNode.string("abc123"),
+                JsonNodeUnmarshallException.class
+        );
     }
 
     @Test
     public void testUnmarshallObjectFails() {
-        this.unmarshallFailed(JsonNode.object(), null);
+        this.unmarshallFailed(
+                JsonNode.object(),
+                JsonNodeUnmarshallException.class
+        );
     }
 
     @Test

--- a/src/test/java/walkingkooka/tree/json/marshall/BasicJsonMarshallerTypedExpressionBinaryExpressionTest.java
+++ b/src/test/java/walkingkooka/tree/json/marshall/BasicJsonMarshallerTypedExpressionBinaryExpressionTest.java
@@ -27,17 +27,26 @@ public final class BasicJsonMarshallerTypedExpressionBinaryExpressionTest extend
 
     @Test
     public void testUnmarshallBooleanFails() {
-        this.unmarshallFailed(JsonNode.booleanNode(true), null);
+        this.unmarshallFailed(
+                JsonNode.booleanNode(true),
+                JsonNodeUnmarshallException.class
+        );
     }
 
     @Test
     public void testUnmarshallNumberFails() {
-        this.unmarshallFailed(JsonNode.number(123), null);
+        this.unmarshallFailed(
+                JsonNode.number(123),
+                JsonNodeUnmarshallException.class
+        );
     }
 
     @Test
     public void testUnmarshallStringFails() {
-        this.unmarshallFailed(JsonNode.string("abc123"), null);
+        this.unmarshallFailed(
+                JsonNode.string("abc123"),
+                JsonNodeUnmarshallException.class
+        );
     }
 
     @Override

--- a/src/test/java/walkingkooka/tree/json/marshall/BasicJsonMarshallerTypedMapTest.java
+++ b/src/test/java/walkingkooka/tree/json/marshall/BasicJsonMarshallerTypedMapTest.java
@@ -40,22 +40,34 @@ public final class BasicJsonMarshallerTypedMapTest extends BasicJsonMarshallerTy
 
     @Test
     public void testUnmarshallBooleanFails() {
-        this.unmarshallFailed(JsonNode.booleanNode(true), null);
+        this.unmarshallFailed(
+                JsonNode.booleanNode(true),
+                JsonNodeUnmarshallException.class
+        );
     }
 
     @Test
     public void testUnmarshallNumberFails() {
-        this.unmarshallFailed(JsonNode.number(123), null);
+        this.unmarshallFailed(
+                JsonNode.number(123),
+                JsonNodeUnmarshallException.class
+        );
     }
 
     @Test
     public void testUnmarshallStringFails() {
-        this.unmarshallFailed(JsonNode.string("abc123"), null);
+        this.unmarshallFailed(
+                JsonNode.string("abc123"),
+                JsonNodeUnmarshallException.class
+        );
     }
 
     @Test
     public void testUnmarshallObjectFails() {
-        this.unmarshallFailed(JsonNode.object(), null);
+        this.unmarshallFailed(
+                JsonNode.object(),
+                JsonNodeUnmarshallException.class
+        );
     }
 
     @Test

--- a/src/test/java/walkingkooka/tree/json/marshall/BasicJsonMarshallerTypedOptionalTest.java
+++ b/src/test/java/walkingkooka/tree/json/marshall/BasicJsonMarshallerTypedOptionalTest.java
@@ -62,10 +62,12 @@ public final class BasicJsonMarshallerTypedOptionalTest extends BasicJsonMarshal
 
     @Test
     public void testUnmarshallArrayTwoElementsFails() {
-        this.unmarshallFailed(JsonNode.array()
+        this.unmarshallFailed(
+                JsonNode.array()
                         .appendChild(JsonNode.number(1))
                         .appendChild(JsonNode.number(2)),
-                null);
+                JsonNodeUnmarshallException.class
+        );
     }
 
     @Test

--- a/src/test/java/walkingkooka/tree/json/marshall/BasicJsonNodeMarshallContextTest.java
+++ b/src/test/java/walkingkooka/tree/json/marshall/BasicJsonNodeMarshallContextTest.java
@@ -24,15 +24,26 @@ import walkingkooka.tree.json.JsonArray;
 import walkingkooka.tree.json.JsonNode;
 import walkingkooka.tree.json.JsonObject;
 import walkingkooka.tree.json.JsonPropertyName;
+import walkingkooka.tree.json.UnsupportedTypeJsonNodeException;
 
 import java.math.RoundingMode;
 import java.util.EnumSet;
 import java.util.Locale;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 public final class BasicJsonNodeMarshallContextTest extends BasicJsonNodeContextTestCase<BasicJsonNodeMarshallContext>
         implements JsonNodeMarshallContextTesting<BasicJsonNodeMarshallContext> {
 
     // marshall.....................................................................................................
+
+    @Test
+    public void testMarshallUnknownTypeFails() {
+        assertThrows(
+                UnsupportedTypeJsonNodeException.class,
+                () -> this.createContext().marshall(this)
+        );
+    }
 
     @Test
     public void testMarshallBooleanTrue() {


### PR DESCRIPTION
…apped fix

- Closes https://github.com/mP1/walkingkooka-tree-json/issues/234
- Improve generic "Unable to unmarshall" to include actual cause in message