### PR TITLE
BasicJsonMarshaller.unmarshall wrap RuntimeException message

### DIFF
--- a/src/main/java/walkingkooka/tree/json/marshall/BasicJsonMarshaller.java
+++ b/src/main/java/walkingkooka/tree/json/marshall/BasicJsonMarshaller.java
@@ -274,7 +274,14 @@ abstract class BasicJsonMarshaller<T> {
         } catch (final JsonNodeException | java.lang.NullPointerException cause) {
             throw cause;
         } catch (final RuntimeException cause) {
-            throw new JsonNodeUnmarshallException("Failed to unmarshall", node, cause);
+            final String message = cause.getMessage();
+            throw new JsonNodeUnmarshallException(
+                    CharSequences.isNullOrEmpty(message) ?
+                            "Unmarshall failed" :
+                            message,
+                    node,
+                    cause
+            );
         }
     }
 


### PR DESCRIPTION
- Previously "Failed to unmarshall" was always the message which was often not useful in the Chrome log.

- Closes https://github.com/mP1/walkingkooka-tree-json/issues/306
- "Failed to unmarshall" should also include type