### PR TITLE
JsonNode.toJsonNode: TextContext replaces Indentation LineEnding

### DIFF
--- a/src/main/java/walkingkooka/tree/json/JsonNode.java
+++ b/src/main/java/walkingkooka/tree/json/JsonNode.java
@@ -28,6 +28,8 @@ import walkingkooka.text.CharSequences;
 import walkingkooka.text.HasText;
 import walkingkooka.text.Indentation;
 import walkingkooka.text.LineEnding;
+import walkingkooka.text.TextContext;
+import walkingkooka.text.TextPrinting;
 import walkingkooka.text.cursor.parser.Parser;
 import walkingkooka.text.printer.IndentingPrinter;
 import walkingkooka.text.printer.Printers;
@@ -443,22 +445,22 @@ public abstract class JsonNode implements Node<JsonNode, JsonPropertyName, Name,
      */
     @Override
     public final String toString() {
-        return this.toJsonText(
-            INDENTATION,
-            LineEnding.SYSTEM
-        );
+        return this.toJsonText(TEXT_CONTEXT);
     }
+
+    private final static TextContext TEXT_CONTEXT = TextPrinting.with(
+        INDENTATION,
+        LineEnding.SYSTEM
+    );
 
     /**
      * Helper that returns this node in json, supporting indentation and using the selected line ending.
      */
-    public final String toJsonText(final Indentation indentation,
-                                   final LineEnding lineEnding) {
-        Objects.requireNonNull(indentation, "indentation");
-        Objects.requireNonNull(lineEnding, "lineEnding");
+    public final String toJsonText(final TextContext context) {
+        Objects.requireNonNull(context, "context");
 
         final StringBuilder b = new StringBuilder();
-        try (final IndentingPrinter printer = Printers.stringBuilder(b, lineEnding).indenting(indentation)) {
+        try (final IndentingPrinter printer = Printers.stringBuilder(b, context.lineEnding()).indenting(context.indentation())) {
             this.printJson(printer);
         }
         return b.toString();

--- a/src/main/java/walkingkooka/tree/json/convert/JsonNodeConverterToJsonNodeText.java
+++ b/src/main/java/walkingkooka/tree/json/convert/JsonNodeConverterToJsonNodeText.java
@@ -65,10 +65,7 @@ final class JsonNodeConverterToJsonNodeText<C extends JsonNodeConverterContext> 
         return this.successfulConversion(
             context.convertOrFail(
                 context.marshall(value)
-                    .toJsonText(
-                        context.indentation(),
-                        context.lineEnding()
-                    ),
+                    .toJsonText(context),
                 type
             ),
             type

--- a/src/test/java/walkingkooka/tree/json/JsonNodeTest.java
+++ b/src/test/java/walkingkooka/tree/json/JsonNodeTest.java
@@ -23,6 +23,7 @@ import walkingkooka.reflect.JavaVisibility;
 import walkingkooka.test.ParseStringTesting;
 import walkingkooka.text.Indentation;
 import walkingkooka.text.LineEnding;
+import walkingkooka.text.TextPrinting;
 import walkingkooka.tree.HasTextOffsetTesting;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -344,26 +345,11 @@ public final class JsonNodeTest implements ClassTesting2<JsonNode>,
     // toJsonText.......................................................................................................
 
     @Test
-    public void testToJsonTextWithNullIndentationFails() {
+    public void testToJsonTextWithNullContextFails() {
         assertThrows(
             NullPointerException.class,
             () -> JsonNode.nullNode()
-                .toJsonText(
-                    null,
-                    LineEnding.NONE
-                )
-        );
-    }
-
-    @Test
-    public void testToJsonTextWithNullLineEndingFails() {
-        assertThrows(
-            NullPointerException.class,
-            () -> JsonNode.nullNode()
-                .toJsonText(
-                    Indentation.SPACES2,
-                    null
-                )
+                .toJsonText(null)
         );
     }
 
@@ -404,8 +390,10 @@ public final class JsonNodeTest implements ClassTesting2<JsonNode>,
         this.checkEquals(
             expected,
             json.toJsonText(
-                indentation,
-                lineEnding
+                TextPrinting.with(
+                    indentation,
+                    lineEnding
+                )
             ),
             json::toString
         );


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-tree-json/issues/586
- JsonNode.toJsonText replace 2 parameters with TextContext