### PR TITLE
JsonNodeParsersGrammar interface was class (mvn annotation-processor)…

### DIFF
--- a/src/main/java/walkingkooka/tree/json/parser/JsonNodeParsersGrammar.java
+++ b/src/main/java/walkingkooka/tree/json/parser/JsonNodeParsersGrammar.java
@@ -17,5 +17,5 @@
 package walkingkooka.tree.json.parser;
 
 @walkingkooka.resource.TextResourceAware(normalizeSpace = true)
-final class JsonNodeParsersGrammar {
+interface JsonNodeParsersGrammar {
 }


### PR DESCRIPTION
… FIX

- This change seems to ensure annotation processors are run by mvn from the command line.